### PR TITLE
Added OSError to error handling when sending teem

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/module_utils/teem.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/module_utils/teem.py
@@ -83,7 +83,7 @@ class TeemClient(object):
                 data=payload
             )
         # we need to ensure that any connection errors to TEEM do not cause failure of module to run.
-        except (HTTPError, URLError, SSLError, RemoteDisconnected):
+        except (HTTPError, URLError, SSLError, RemoteDisconnected, OSError):
             return None
 
         ok = re.search(r'20[01-4]', str(response.code))


### PR DESCRIPTION
# summary
Use f5_module to operate BIG-IP with aws-operator.
Yesterday, all of a sudden our job started to fail, and upon investigation, we found an exception on `socket.timeout` when sending a teem.
We worked around the problem by setting the `no_f5_teem` option, but I don't think it is desirable to have the module process fail due to a TEEM error.
Since `socket.timeout` is a subclass of OSError, we added OSError to the exception handling target.

- Reference
https://docs.python.org/3.9/library/socket.html#exceptions

# Log when problems occur
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: socket.timeout: The read operation timed out
fatal: [XXXXXX -> localhost({{ inventory_hostname }}.{{ host_domain }})]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):
  File \\"/root/.ansible/tmp/ansible-tmp-1744800535.145826-32-105060651175105/AnsiballZ_bigip_pool_member.py\\", line 107, in <module>
    _ansiballz_main()
  File \\"/root/.ansible/tmp/ansible-tmp-1744800535.145826-32-105060651175105/AnsiballZ_bigip_pool_member.py\\", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \\"/root/.ansible/tmp/ansible-tmp-1744800535.145826-32-105060651175105/AnsiballZ_bigip_pool_member.py\\", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.f5networks.f5_modules.plugins.modules.bigip_pool_member', init_globals=dict(_module_fqn='ansible_collections.f5networks.f5_modules.plugins.modules.bigip_pool_member', _modlib_path=modlib_path),
  File \\"/usr/lib64/python3.9/runpy.py\\", line 225, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File \\"/usr/lib64/python3.9/runpy.py\\", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File \\"/usr/lib64/python3.9/runpy.py\\", line 87, in _run_code
    exec(code, run_globals)
  File \\"/tmp/ansible_bigip_pool_member_payload_38szm472/ansible_bigip_pool_member_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_pool_member.py\\", line 1826, in <module>
  File \\"/tmp/ansible_bigip_pool_member_payload_38szm472/ansible_bigip_pool_member_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_pool_member.py\\", line 1819, in main
  File \\"/tmp/ansible_bigip_pool_member_payload_38szm472/ansible_bigip_pool_member_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_pool_member.py\\", line 1223, in exec_module
  File \\"/tmp/ansible_bigip_pool_member_payload_38szm472/ansible_bigip_pool_member_payload.zip/ansible_collections/f5networks/f5_modules/plugins/module_utils/teem.py\\", line 166, in send_teem
  File \\"/tmp/ansible_bigip_pool_member_payload_38szm472/ansible_bigip_pool_member_payload.zip/ansible_collections/f5networks/f5_modules/plugins/module_utils/teem.py\\", line 77, in send
  File \\"/tmp/ansible_bigip_pool_member_payload_38szm472/ansible_bigip_pool_member_payload.zip/ansible/module_utils/urls.py\\", line 1686, in open_url
  File \\"/tmp/ansible_bigip_pool_member_payload_38szm472/ansible_bigip_pool_member_payload.zip/ansible/module_utils/urls.py\\", line 1578, in open
  File \\"/usr/lib64/python3.9/urllib/request.py\\", line 214, in urlopen
    return opener.open(url, data, timeout)
  File \\"/usr/lib64/python3.9/urllib/request.py\\", line 517, in open
    response = self._open(req, data)
  File \\"/usr/lib64/python3.9/urllib/request.py\\", line 534, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File \\"/usr/lib64/python3.9/urllib/request.py\\", line 494, in _call_chain
    result = func(*args)
  File \\"/tmp/ansible_bigip_pool_member_payload_38szm472/ansible_bigip_pool_member_payload.zip/ansible/module_utils/urls.py\\", line 605, in https_open
  File \\"/usr/lib64/python3.9/urllib/request.py\\", line 1350, in do_open
    r = h.getresponse()
  File \\"/usr/lib64/python3.9/http/client.py\\", line 1377, in getresponse
    response.begin()
  File \\"/usr/lib64/python3.9/http/client.py\\", line 320, in begin
    version, status, reason = self._read_status()
  File \\"/usr/lib64/python3.9/http/client.py\\", line 281, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), \\"iso-8859-1\\")
  File \\"/usr/lib64/python3.9/socket.py\\", line 704, in readinto
    return self._sock.recv_into(b)
  File \\"/usr/lib64/python3.9/ssl.py\\", line 1275, in recv_into
    return self.read(nbytes, buffer)
  File \\"/usr/lib64/python3.9/ssl.py\\", line 1133, in read
    return self._sslobj.read(len, buffer)
socket.timeout: The read operation timed out
", "module_stdout": "", "msg": "MODULE FAILURE
See stdout/stderr for the exact error", "rc": 1}
```