### PR TITLE
Fix bigip_user module's doc. Adding log-manager role to partition_acc…

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_user.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_user.py
@@ -51,7 +51,7 @@ options:
         C(partition_access) is required when creating a new account, and
         should be in the form "partition:role".
       - Valid roles include C(acceleration-policy-editor), C(admin), C(application-editor),
-        C(auditor), C(certificate-manager), C(guest), C(irule-manager), C(manager), C(no-access),
+        C(auditor), C(certificate-manager), C(guest), C(irule-manager), C(log-manager), C(manager), C(no-access),
         C(operator), C(resource-admin), C(user-manager), C(web-application-security-administrator),
         and C(web-application-security-editor).
       - The partition portion the of tuple should be an existing partition or the value 'all'.


### PR DESCRIPTION
**Summary:**
This PR updates the documentation for the `f5networks.f5_modules.bigip_user` module to include a missing valid choice.

**The Problem:**
The `DOCUMENTATION` string for the `bigip_user` module's `partition_access` parameter does not list `log-manager` as a valid `choice` for the `role` sub-option.

Here is the F5 BIG-IP v17.x documentation for the user's roles: https://techdocs.f5.com/en-us/bigip-17-0-0/big-ip-systems-user-account-administration/user-roles.html

**The Fix:**
According to our testing on BIG-IP v17.x (and confirmed by the user in this playbook), the `log-manager` role is indeed accepted by the API when set as a partition role.

Example Playbook:
```
  tasks:
    - name: Update the user 'johnd' as an Log Manager
      f5networks.f5_modules.bigip_user:
        username_credential: johnd
        password_credential: password
        full_name: John Doe
        partition_access:
          - all:log-manager
        update_password: on_create
        provider:
          server: lb.mydomain.com
          user: admin
          password: secret
        state: present
      delegate_to: localhost
```

This PR adds `log-manager` to the `choices` list, so that the generated documentation on docs.ansible.com reflects the module's actual capabilities.
